### PR TITLE
"Fix grammatical error in README: Changed 'allows' to 'allow' in GeoNode MapStore Client documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Build Status](https://github.com/GeoNode/geonode-mapstore-client/actions/workflows/test.yml/badge.svg)
 
-GeoNode MapStore Client is a frontend application that interacts with the GeoNode API V2 to allows users to navigate and discover GeoNode resources. The client application provided by this repository is a MapStore downstream project an Open Source WebGIS framework based on ReactJS. 
+GeoNode MapStore Client is a frontend application that interacts with the GeoNode API V2 to allow users to navigate and discover GeoNode resources. The client application provided by this repository is a MapStore downstream project an Open Source WebGIS framework based on ReactJS. 
 
 ## Tools supported versions
 


### PR DESCRIPTION
### Pull Request Description

This pull request addresses a grammatical error in the README file for the GeoNode MapStore Client project.

**Changes Made:**

- Corrected the grammatical error where "allows" was changed to "allow" to agree with "to."

**Details:**

In the README file, the sentence originally read:
> GeoNode MapStore Client is a frontend application that interacts with the GeoNode API V2 to allows users to navigate and discover GeoNode resources.

The phrase "to allows" was corrected to "to allow" to ensure proper grammar and clarity.

**Impact:**

This correction improves the readability and professionalism of the documentation.